### PR TITLE
Fix:いいね 機能編集・ヘッダー編集

### DIFF
--- a/app/assets/stylesheets/_items-show.scss
+++ b/app/assets/stylesheets/_items-show.scss
@@ -139,11 +139,14 @@
               margin-right: auto;
               padding: 6px 10px;
               border-radius: 40px;
-              color: #3CCACE;
+              color: #ffb340;
               border: 1px solid #ffb340;
               &__icon {
                 margin: auto;
-                color: #3CCACE;
+                color: #ffb340;
+              }
+              a {
+                color: #ffb340;
               }
             }
             .like:hover {

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -30,7 +30,7 @@
                   %li= image_tag image.image_name.url, class: 'gallery'
         .content__form__price
           .price
-            = @product.price
+            = "¥#{@product.price}"
           .tax
             (税込) 送料込み
         .content__form__text
@@ -76,16 +76,19 @@
         .content__form__option
           .option
             .like
-              - if current_user.already_liked?(@product)
-                = link_to item_like_path(@product), method: :delete do
-                  = icon('fas','star', class: 'like__icon')
-                  お気に入り
-                = @product.liked_users.count
+              - if user_signed_in?
+                - if current_user.already_liked?(@product)
+                  = link_to item_like_path(@product), method: :delete do
+                    = icon('fas','star', class: 'like__icon')
+                    お気に入り：
+                  = @product.liked_users.count
+                - else
+                  = link_to item_likes_path(@product), method: :post do
+                    = icon('far', 'star', class: 'like__icon')
+                    お気に入り：
+                  = @product.liked_users.count
               - else
-                = link_to item_likes_path(@product), method: :post do
-                  = icon('far', 'star', class: 'like__icon')
-                  お気に入り
-                = @product.liked_users.count
+                お気に入りには登録が必要です
           .option
             .report
               = icon('fa', 'flag', class: 'report__icon')

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -14,7 +14,7 @@
         %li
         = link_to 'カテゴリー', '#', class: 'choice'
         %li
-        = link_to 'ブランド', '#', class: 'choice'
+        = link_to '出品中の商品一覧', items_path, class: 'choice'
       .navi__right
         - if user_signed_in?
           =link_to 'マイページ', "/users/#{current_user.id}"

--- a/app/views/likes/index.html.haml
+++ b/app/views/likes/index.html.haml
@@ -26,7 +26,7 @@
                 .text
                   = like.product.name
                 .text
-                  = like.product.price
+                  = "¥#{like.product.price}"
   .likes-side
     .likes-navi
       %ul


### PR DESCRIPTION
# What
・商品詳細ページにおいて、お気に入り機能の条件分岐を編集。
ログアウト状態（未登録）では、いいね数を確認する為に
登録が必要と説明を添え、ビューを表示。
・ヘッダーにて現在出品中商品へのリンクを設置。

# Why
・現状のお気に入り機能の条件分岐では、ログアウト状態（未登録）において
ページ自体表示できない状態だった為。
・ヘッダーのリンクを経由し、出品中商品の確認ができるようにする為。