### PR TITLE
未ログイン時のnew、editアクションの非表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   #他ユーザーの情報は表示しない
+  before_action :authenticate_user,{only: [:new,:create,:edit,:update]}
   before_action :ensure_correct_user, {only: [:edit,:update]} 
   before_action :set_item, {only: [:edit,:update]}
   GROUP_ITEM_STATUS = 100
@@ -161,9 +162,15 @@ class ItemsController < ApplicationController
   end
 
   def ensure_correct_user
-    current_item = Product.find(params[:id])
-    if current_item.user_id != current_user.id
+    current_item = Product.find_by(id:params[:id])
+    if current_item.nil? || current_item.user_id != current_user.id
       redirect_to root_path
+    end
+  end
+
+  def authenticate_user
+    if !user_signed_in?
+      redirect_to new_user_session_path
     end
   end
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -166,7 +166,7 @@
       %hr
       .actions
         =f.submit "出品する", class: 'actions__submit-button'
-        = link_to "もどる","#",class: "back"
+        = link_to "もどる",item_path(@item.id),class: "back"
       %p.note
         禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。
 #input-images-count.display-none{ data: {input_images_count:@item.product_images.length}}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -141,6 +141,6 @@
       %hr
       .actions
         =f.submit "出品する", class: 'actions__submit-button'
-        = link_to "もどる","#",class: "back"
+        = link_to "もどる",root_path,class: "back"
       %p.note
         禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。


### PR DESCRIPTION
# what
未ログイン時、itemコントローラーのnew,create,edit,updateアクションは行えず、ログイン画面へ遷移させる
# why
ログインユーザーでのみ商品の出品、編集を行えるようにするため
