### PR TITLE
fields_for からimage_nameのhidden_fieldを削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,7 +58,7 @@ class ItemsController < ApplicationController
     end
   end
   def update
-    # begin
+    begin
       delete_count = 0
       image_length = 0
       is_image_valid = false
@@ -85,11 +85,11 @@ class ItemsController < ApplicationController
         set_edit_default_value
         render :edit
       end
-    # rescue => exception
-    #   @error_messages = "例外処理が発生しました"
-    #   set_edit_default_value
-    #   render :edit
-    # end
+    rescue => exception
+      @error_messages = "例外処理が発生しました"
+      set_edit_default_value
+      render :edit
+    end
   end
 
   def show

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -6,7 +6,7 @@
     -@item.errors.full_messages.each do |message|
       .form-error
         = message
-    = form_with model: [@item] ,url: item_path,local: true,multipart: true do |f|
+    = form_with model: [@item] ,url: item_path,local: true do |f|
       .item-images
         .item-images__label.label
           出品画像
@@ -32,7 +32,6 @@
             %label#input-label
               = f.fields_for :product_images do |image|
                 = image.file_field :image_name
-                = image.hidden_field :image_name
                 = image.hidden_field :id,value: image.object.id
                 = image.check_box:_destroy
               .file-area


### PR DESCRIPTION
# what
image_nameのhidden_fieldは使用していないため、削除する
# why
この記述があると、update時image_name列にnullが入ってしまいDB側でエラーとなる。
おそらくcarrierwave側の挙動で怪しい部分がある
