### PR TITLE
add:商品購入画面へのリンクを挿入

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -114,7 +114,7 @@
         .buy
           .buy__form
             = icon('fa', 'cart-arrow-down')
-            = link_to '購入画面にすすむ', '#'
+            = link_to '購入画面にすすむ', new_order_path(id: @product.id)
       - unless user_signed_in? && current_user.id && @product.user_id
         .unregistered
           購入には新規登録/ログインが必要です


### PR DESCRIPTION
# What
商品詳細画面の購入ボタンから
商品購入画面（クレジットカード未登録の場合、クレジットカード登録画面）
へのリンクを設置。

# Why
アプリ使用時、ユーザーが商品詳細画面より、購入手続きを進められるようにする為。