### PR TITLE
商品詳細ページの下記リンク修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -129,5 +129,5 @@
             後の商品
             = icon('fa', 'angle-right', class: 'right__icon')
       .relate
-        = link_to "キッズをもっと見る", '#'
+        = link_to "#{@parent.name}をもっと見る" , '#'
 = render partial: 'layouts/footer'


### PR DESCRIPTION
# What
商品詳細ページの下記リンクを
カテゴリーの第一分類が表示(のみ)されるように編集。

# Why
見た目改善目的。